### PR TITLE
[#155523550] Store positions offsets in the index for highlightable fields

### DIFF
--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -250,6 +250,7 @@ class Documents
           json.mapping do
             json.analyzer "#{locale}_analyzer"
             json.type "text"
+            json.term_vector "with_positions_offsets"
             json.copy_to 'bigrams'
           end
         end

--- a/spec/classes/document_search_spec.rb
+++ b/spec/classes/document_search_spec.rb
@@ -498,7 +498,7 @@ describe DocumentSearch do
 
     it 'should return exact matches only' do
       expect(document_search_results.total).to eq 1
-      expect(document_search_results.results.first['content']).to eq "amazing spiderman"
+      expect(document_search_results.results.first['content']).to eq "amazing spiderman"
     end
   end
 


### PR DESCRIPTION
@nickmarden this index settings change instructs Elasticsearch to store additional info in i14y indices that makes the highlighting logic faster and less resource intensive. It trades more storage needs for more efficient highlighting.

There were no index settings specs for me to change, but interestingly this change did break one spec. I think the new spec expectation is actually more reasonable than the old expectation. When someone searches for `"amazing spiderman"` (with quotes), the results before this change would involve both "amazing" and "spiderman" being highlighted individually. The results after this change involve both words being highlighted together as one big highlighted chunk. It doesn't matter on SERPs though because the result looks exactly the same when rendered (`<b>foo</b> <b>bar</b>` looks the same as `<b>foo bar</b>`).

I verified that this change does noticeably increase the speed of highlighting giant chunks of text (7MB) and also reduces the heap pressure caused by highlighting giant chunks of text. These findings are in line with recommendations I've seen in various places for using fast vector highlighting when large text fields sometimes come into play.