### PR TITLE
[SRCH-402] prefer documents with higher click_count values

### DIFF
--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -91,12 +91,28 @@ class DocumentQuery
 
   def functions
     [
-      { gauss: { created: { origin: 'now', scale: '1825d', offset: '30d', decay: 0.3 } } },
-      { filter: {
+      # Prefer more recent documents
+      {
+        gauss: {
+          created: { origin: 'now', scale: '1825d', offset: '30d', decay: 0.3 }
+        }
+      },
+
+      # Avoid pdfs, etc.
+      {
+        filter: {
           terms: {
             extension: %w(doc docx pdf ppt pptx xls xlsx)
-          } },
+          }
+        },
         weight: -3
+      },
+
+      # Prefer documents that have been clicked more often
+      {
+        field_value_factor: {
+          field: 'click_count', modifier: 'log1p', factor: 2, missing: 1
+        }
       }
     ]
   end

--- a/spec/classes/document_search_spec.rb
+++ b/spec/classes/document_search_spec.rb
@@ -288,6 +288,26 @@ describe DocumentSearch do
         expect(document_search_results.results.first['tags']).to match_array(['stats'])
       end
     end
+
+    context 'when documents include click counts' do
+      before do
+        Document.create(common_params.merge(path: 'http://agency.gov/popular'))
+        Document.create(common_params.merge(path: 'http://agency.gov/most_popular',
+                                            click_count: 10))
+        Document.create(common_params.merge(path: 'http://agency.gov/more_popular',
+                                            click_count: 5))
+        Document.refresh_index!
+      end
+
+      it 'ranks documents with higher click counts higher' do
+        paths = document_search_results.results.map { |doc| doc[:path] }
+        expect(paths).to eq (
+          %w[http://agency.gov/most_popular
+             http://agency.gov/more_popular
+             http://agency.gov/popular]
+        )
+      end
+    end
   end
 
   describe "sorting by date" do


### PR DESCRIPTION
Add a `field_value_factor` function to prefer documents with higher `click_count` values.