### PR TITLE
SRCH-551 set "changed" as "created" when missing

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -22,6 +22,8 @@ class Document
   attribute :tags, String, mapping: { type: 'keyword' }
   attribute :click_count, Integer
 
+  before_save { self.changed = changed.presence || created }
+
   LANGUAGE_FIELDS = [:title, :description, :content]
 
   gateway do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,9 +1,26 @@
 require 'rails_helper'
 
 describe Document do
+  let(:valid_params) do
+    {
+      _id: 'a123',
+      language: 'en',
+      path: 'http://www.agency.gov/page1.html',
+      title: 'My Title',
+      created: DateTime.now,
+      changed: DateTime.now,
+      description: 'My Description',
+      content: 'some content',
+      promote: true,
+      tags: 'this,that'
+    }
+  end
+
   before(:all) do
     handle = 'test_index'
-    Elasticsearch::Persistence.client.indices.delete(index: [Document.index_namespace(handle), '*'].join('-'))
+    Elasticsearch::Persistence.client.indices.delete(
+      index: [Document.index_namespace(handle), '*'].join('-')
+    )
     es_documents_index_name = [Document.index_namespace(handle), 'v1'].join('-')
     Document.create_index!(index: es_documents_index_name)
     Elasticsearch::Persistence.client.indices.put_alias index: es_documents_index_name,
@@ -12,23 +29,50 @@ describe Document do
   end
 
   after(:all) do
-    Elasticsearch::Persistence.client.indices.delete(index: [Document.index_namespace('test_index'), '*'].join('-'))
+    Elasticsearch::Persistence.client.indices.delete(
+      index: [Document.index_namespace('test_index'), '*'].join('-')
+    )
   end
 
-  context 'language fields contain HTML/CSS and HTML entities' do
-    before do
-      html = %[
-  <div style="height: 100px; width: 100px;"></div>
-  <p>hello & goodbye!</p>
-]
-      Document.create(_id: 'a123', language: 'en', title: '<b><a href="http://foo.com/">foo</a></b><img src="bar.jpg">', description: html, created: DateTime.now, path: 'http://www.agency.gov/page1.html', content: "this <b>is</b> <a href='http://gov.gov/url.html'>html</a>")
+  describe '.create' do
+    context 'when language fields contain HTML/CSS and HTML entities' do
+      let(:html) do
+        <<~HTML
+          <div style="height: 100px; width: 100px;"></div>
+          <p>hello & goodbye!</p>
+        HTML
+      end
+
+      before do
+        Document.create(_id: 'a123',
+                        language: 'en',
+                        title: '<b><a href="http://foo.com/">foo</a></b><img src="bar.jpg">',
+                        description: html,
+                        created: DateTime.now,
+                        path: 'http://www.agency.gov/page1.html',
+                        content: "this <b>is</b> <a href='http://gov.gov/url.html'>html</a>")
+      end
+
+      it 'sanitizes the language fields' do
+        document = Document.find 'a123'
+        expect(document.title).to eq('foo')
+        expect(document.description).to eq('hello & goodbye!')
+        expect(document.content).to eq('this is html')
+      end
     end
 
-    it 'sanitizes the language fields' do
-      document = Document.find 'a123'
-      expect(document.title).to eq("foo")
-      expect(document.description).to eq("hello & goodbye!")
-      expect(document.content).to eq("this is html")
+    context 'when a created value is provided but not changed' do
+      let(:params_without_changed) do
+        valid_params.merge(created: DateTime.now, changed: '')
+      end
+
+      before { Document.create(params_without_changed) }
+
+      it 'sets "changed" to be the same as "created"' do
+        Document.create(params_without_changed)
+        document = Document.find('a123')
+        expect(document.changed).to eq document.created
+      end
     end
   end
 end

--- a/spec/requests/api/v1/collections_spec.rb
+++ b/spec/requests/api/v1/collections_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe API::V1::Collections do
   let(:valid_session) do
-    yaml = YAML.load_file("#{Rails.root}/config/secrets.yml")
-    env_secrets = yaml[Rails.env]
-    credentials = ActionController::HttpAuthentication::Basic.encode_credentials env_secrets['admin_user'], env_secrets['admin_password']
+    env_secrets = Rails.application.config_for(:secrets)
+    credentials = ActionController::HttpAuthentication::Basic.encode_credentials(
+      env_secrets['admin_user'], env_secrets['admin_password']
+    )
     { 'HTTP_AUTHORIZATION' => credentials }
   end
 
@@ -18,26 +19,34 @@ describe API::V1::Collections do
     I14y::Application.config.updates_allowed = true
   end
 
-  describe "POST /api/v1/collections" do
+  describe 'POST /api/v1/collections' do
     context 'success case' do
       before do
-        Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
-        valid_params = { "handle" => "agency_blogs", "token" => "secret" }
-        post "/api/v1/collections", params: valid_params, headers: valid_session
+        Elasticsearch::Persistence.client.delete_by_query(
+          index: Collection.index_name,
+          q: '*:*',
+          conflicts: 'proceed'
+        )
+        valid_params = { handle: 'agency_blogs', token: 'secret' }
+        post '/api/v1/collections', params: valid_params, headers: valid_session
       end
 
       it 'returns success message as JSON' do
         expect(response.status).to eq(201)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 200, "developer_message" => "OK", "user_message" => "Your collection was successfully created."))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 200,
+                         'developer_message' => 'OK',
+                         'user_message' => 'Your collection was successfully created.')
+        )
       end
 
       it 'uses the collection handle as the Elasticsearch ID' do
-        expect(Collection.find("agency_blogs")).to be_present
+        expect(Collection.find('agency_blogs')).to be_present
       end
 
       it 'stores the appropriate fields in the Elasticsearch collection' do
-        collection = Collection.find("agency_blogs")
-        expect(collection.token).to eq("secret")
+        collection = Collection.find('agency_blogs')
+        expect(collection.token).to eq('secret')
       end
 
       it_behaves_like 'a data modifying request made during read-only mode'
@@ -46,124 +55,167 @@ describe API::V1::Collections do
     context 'a required parameter is empty/blank' do
       before do
         invalid_params = {}
-        post "/api/v1/collections", params: invalid_params, headers: valid_session
+        post '/api/v1/collections', params: invalid_params, headers: valid_session
       end
 
       it 'returns failure message as JSON' do
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 400, "developer_message" => "handle is missing, handle is empty, token is missing, token is empty"))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 400,
+                         'developer_message' => 'handle is missing, handle is empty, token is missing, token is empty')
+        )
       end
     end
 
     context 'handle uses illegal characters' do
       before do
-        invalid_params = { "handle" => "agency-blogs", "token" => "secret" }
-        post "/api/v1/collections", params: invalid_params, headers: valid_session
+        invalid_params = { 'handle' => 'agency-blogs', 'token' => 'secret' }
+        post '/api/v1/collections', params: invalid_params, headers: valid_session
       end
 
       it 'returns failure message as JSON' do
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 400, "developer_message" => "handle is invalid"))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 400,
+                         'developer_message' => 'handle is invalid')
+        )
       end
     end
 
     context 'failed authentication/authorization' do
       before do
-        valid_params = { "handle" => "agency_blogs", "token" => "secret" }
-        bad_credentials = ActionController::HttpAuthentication::Basic.encode_credentials "nope", "wrong"
+        valid_params = { 'handle' => 'agency_blogs', 'token' => 'secret' }
+        bad_credentials = ActionController::HttpAuthentication::Basic.encode_credentials 'nope', 'wrong'
 
         valid_session = { 'HTTP_AUTHORIZATION' => bad_credentials }
-        post "/api/v1/collections", params: valid_params, headers: valid_session
+        post '/api/v1/collections', params: valid_params, headers: valid_session
       end
 
       it 'returns error message as JSON' do
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 400, "developer_message" => "Unauthorized"))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 400,
+                         'developer_message' => 'Unauthorized')
+        )
       end
     end
 
     context 'something terrible happens' do
       before do
         allow(Collection).to receive(:create) { raise_error(Exception) }
-        valid_params = { "handle" => "agency_blogs", "token" => "secret" }
-        post "/api/v1/collections", params: valid_params, headers: valid_session
+        valid_params = { 'handle' => 'agency_blogs', 'token' => 'secret' }
+        post '/api/v1/collections', params: valid_params, headers: valid_session
       end
 
       it 'returns failure message as JSON' do
         expect(response.status).to eq(500)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 500, "developer_message" => "Something unexpected happened and we've been alerted."))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 500,
+                         'developer_message' => "Something unexpected happened and we've been alerted.")
+        )
       end
     end
 
   end
 
-  describe "DELETE /api/v1/collections/{handle}" do
+  describe 'DELETE /api/v1/collections/{handle}' do
     context 'success case' do
       before do
         Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
-        Collection.create(_id: "agency_blogs", token: "secret")
-        delete "/api/v1/collections/agency_blogs", headers: valid_session
+        Collection.create(_id: 'agency_blogs', token: 'secret')
+        delete '/api/v1/collections/agency_blogs', headers: valid_session
       end
 
       it 'returns success message as JSON' do
         expect(response.status).to eq(200)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 200, "developer_message" => "OK", "user_message" => "Your collection was successfully deleted."))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 200,
+                         'developer_message' => 'OK',
+                         'user_message' => 'Your collection was successfully deleted.')
+        )
       end
 
       it 'deletes the collection' do
-        expect(Collection.exists?("agency_blogs")).to be_falsey
+        expect(Collection.exists?('agency_blogs')).to be_falsey
       end
 
       it_behaves_like 'a data modifying request made during read-only mode'
     end
   end
 
-  describe "GET /api/v1/collections/{handle}" do
+  describe 'GET /api/v1/collections/{handle}' do
     context 'success case' do
       before do
         Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
-        valid_params = { "handle" => "agency_blogs", "token" => "secret" }
-        post "/api/v1/collections", params: valid_params, headers: valid_session
+        valid_params = { 'handle' => 'agency_blogs', 'token' => 'secret' }
+        post '/api/v1/collections', params: valid_params, headers: valid_session
         Document.index_name = Document.index_namespace('agency_blogs')
         Elasticsearch::Persistence.client.delete_by_query index: Document.index_name, q: '*:*', conflicts: 'proceed'
       end
 
       let(:datetime) { DateTime.now.utc }
-      let(:hash1) { { _id: 'a1', language: 'en', title: 'title 1 common content', description: 'description 1 common content', created: Time.now, path: 'http://www.agency.gov/page1.html' } }
-      let(:hash2) { { _id: 'a2', language: 'en', title: 'title 2 common content', description: 'description 2 common content', created: Time.now, path: 'http://www.agency.gov/page2.html' } }
+      let(:hash1) do
+        {
+          _id: 'a1',
+          language: 'en',
+          title: 'title 1 common content',
+          description: 'description 1 common content',
+          created: Time.now,
+          path: 'http://www.agency.gov/page1.html'
+        }
+      end
+      let(:hash2) do
+        {
+          _id: 'a2',
+          language: 'en',
+          title: 'title 2 common content',
+          description: 'description 2 common content',
+          created: Time.now,
+          path: 'http://www.agency.gov/page2.html'
+        }
+      end
 
       it 'returns success message with Collection stats as JSON' do
         Document.create(hash1)
         Document.create(hash2)
         Document.refresh_index!
-        get "/api/v1/collections/agency_blogs", headers: valid_session
+        get '/api/v1/collections/agency_blogs', headers: valid_session
         expect(response.status).to eq(200)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 200, "developer_message" => "OK", "collection" => { "document_total" => 2, "last_document_sent" => an_instance_of(String), "token" => "secret", "id" => "agency_blogs", "created_at" => an_instance_of(String), "updated_at" => an_instance_of(String) }))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 200,
+                         'developer_message' => 'OK',
+                         'collection' => { 'document_total' => 2,
+                                           'last_document_sent' => an_instance_of(String),
+                                           'token' => 'secret',
+                                           'id' => 'agency_blogs',
+                                           'created_at' => an_instance_of(String),
+                                           'updated_at' => an_instance_of(String) })
+        )
       end
 
     end
   end
 
-  describe "GET /api/v1/collections/search" do
+  describe 'GET /api/v1/collections/search' do
     context 'success case' do
       before do
         Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
-        valid_params = { "handle" => "agency_blogs", "token" => "secret" }
-        post "/api/v1/collections", params: valid_params, headers: valid_session
+        valid_params = { 'handle' => 'agency_blogs', 'token' => 'secret' }
+        post '/api/v1/collections', params: valid_params, headers: valid_session
         Document.index_name = Document.index_namespace('agency_blogs')
         Elasticsearch::Persistence.client.delete_by_query index: Document.index_name, q: '*:*', conflicts: 'proceed'
       end
 
-      let(:datetime) { DateTime.now.utc }
+      let(:datetime) { DateTime.now.utc.to_s }
       let(:hash1) { { _id: 'a1',
                       language: 'en',
                       title: 'title 1 common content',
                       description: 'description 1 common content',
                       content: 'content 1 common content',
-                      created: datetime.to_s,
+                      created: datetime,
                       path: 'http://www.agency.gov/page1.html',
-                      promote: true, updated: datetime.to_s,
-                      updated_at: datetime.to_s } }
+                      promote: true, updated: datetime,
+                      updated_at: datetime } }
       let(:hash2) { { _id: 'a2',
                       language: 'en',
                       title: 'title 2 common content',
@@ -172,28 +224,61 @@ describe API::V1::Collections do
                       created: datetime.to_s,
                       path: 'http://www.agency.gov/page2.html',
                       promote: false, tags: 'tag1, tag2',
-                      updated_at: datetime.to_s } }
+                      updated_at: datetime } }
 
       it 'returns highlighted JSON search results' do
         Document.create(hash1)
         Document.create(hash2)
         Document.refresh_index!
-        valid_params = { 'language' => 'en', 'query' => 'common contentx', 'handles' => 'agency_blogs' }
-        get "/api/v1/collections/search", params: valid_params, headers: valid_session
+        valid_params = { language: 'en', query: 'common contentx', handles: 'agency_blogs' }
+        get '/api/v1/collections/search', params: valid_params, headers: valid_session
         expect(response.status).to eq(200)
-        metadata_hash = { 'total' => 2, 'offset' => 0, "suggestion" => { "text" => "common content", "highlighted" => "common content" } }
-        result1 = { "language" => "en", "created" => datetime.to_s, "path" => 'http://www.agency.gov/page1.html', "title" => 'title 1 common content', "description" => 'description 1 common content', "content" => 'content 1 common content', "changed" => nil }
-        result2 = { "language" => "en", "created" => datetime.to_s, "path" => 'http://www.agency.gov/page2.html', "title" => 'title 2 common content', "description" => 'description 2 common content',  "changed" => nil }
+        metadata_hash = {
+                          'total' => 2,
+                          'offset' => 0,
+                          'suggestion' => { 'text' => 'common content',
+                                            'highlighted' => 'common content' }
+                        }
+        result1 = {
+                    'language' => 'en',
+                    'created' => datetime,
+                    'path' => 'http://www.agency.gov/page1.html',
+                    'title' => 'title 1 common content',
+                    'description' => 'description 1 common content',
+                    'content' => 'content 1 common content',
+                    'changed' => datetime
+                  }
+        result2 = {
+                    'language' => 'en',
+                    'created' => datetime,
+                    'path' => 'http://www.agency.gov/page2.html',
+                    'title' => 'title 2 common content',
+                    'description' => 'description 2 common content',
+                    'changed' => datetime
+                  }
         results_array = [result1, result2]
         expect(JSON.parse(response.body)).to match(
-          hash_including('status' => 200, "developer_message" => "OK", "metadata" => metadata_hash, 'results' => results_array))
+          hash_including('status' => 200,
+                         'developer_message' => 'OK',
+                         'metadata' => metadata_hash,
+                         'results' => results_array)
+        )
       end
 
-      it "uses the appropriate parameters for the DocumentSearch" do
-        valid_params = { 'language' => 'en', 'query' => 'common content', 'handles' => 'agency_blogs',
-                         'sort_by_date' => 1, 'min_timestamp' => '2013-02-27T10:00:00Z',
-                         'max_timestamp' => '2013-02-27T10:01:00Z', 'offset' => 2**32, 'size' => 3,
-                         'tags' => 'Foo, Bar blat', 'ignore_tags' => 'ignored', 'include' => 'title,description' }
+      it 'uses the appropriate parameters for the DocumentSearch' do
+        valid_params = {
+                         language: 'en',
+                         query: 'common content',
+                         handles: 'agency_blogs',
+                         sort_by_date: 1,
+                         min_timestamp: '2013-02-27T10:00:00Z',
+                         max_timestamp: '2013-02-27T10:01:00Z',
+                         offset: 2**32,
+                         size: 3,
+                         tags: 'Foo, Bar blat',
+                         ignore_tags: 'ignored',
+                         include: 'title,description'
+                       }
         expected_params = Hashie::Mash.new('language' => :en,
                                            'query' => 'common content',
                                            'handles' => %w(agency_blogs),
@@ -207,26 +292,31 @@ describe API::V1::Collections do
                                            'include' => ['title', 'description']
         )
         expect(DocumentSearch).to receive(:new).with(expected_params)
-        get "/api/v1/collections/search", params: valid_params, headers: valid_session
+        get '/api/v1/collections/search', params: valid_params, headers: valid_session
       end
     end
 
     context 'no results' do
       before do
         Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
-        valid_params = { "handle" => "agency_blogs", "token" => "secret" }
-        post "/api/v1/collections", params: valid_params, headers: valid_session
+        valid_params = { 'handle' => 'agency_blogs', 'token' => 'secret' }
+        post '/api/v1/collections', params: valid_params, headers: valid_session
         Document.index_name = Document.index_namespace('agency_blogs')
         Elasticsearch::Persistence.client.delete_by_query index: Document.index_name, q: '*:*', conflicts: 'proceed'
       end
 
       it 'returns JSON no hits results' do
         valid_params = { 'language' => 'en', 'query' => 'no hits', 'handles' => 'agency_blogs' }
-        get "/api/v1/collections/search", params: valid_params, headers: valid_session
+        get '/api/v1/collections/search', params: valid_params, headers: valid_session
         expect(response.status).to eq(200)
         metadata_hash = { 'total' => 0, 'offset' => 0, 'suggestion' => nil }
         results_array = []
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 200, "developer_message" => "OK", "metadata" => metadata_hash, 'results' => results_array))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 200,
+                         'developer_message' => 'OK',
+                         'metadata' => metadata_hash,
+                         'results' => results_array)
+        )
       end
 
     end
@@ -234,26 +324,31 @@ describe API::V1::Collections do
     context 'missing required params' do
       before do
         invalid_params = {}
-        get "/api/v1/collections/search", params: invalid_params, headers: valid_session
+        get '/api/v1/collections/search', params: invalid_params, headers: valid_session
       end
 
       it 'returns error message as JSON' do
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to match(hash_including('status' => 400, "developer_message" => "handles is missing, handles is empty"))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('status' => 400,
+                         'developer_message' => 'handles is missing, handles is empty')
+        )
       end
     end
 
     context 'searching across one or more collection handles that do not exist' do
       before do
         Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
-        Collection.create(_id: "agency_blogs", token: "secret")
+        Collection.create(_id: 'agency_blogs', token: 'secret')
         bad_handle_params = { 'language' => 'en', 'query' => 'foo', 'handles' => 'agency_blogs,missing' }
-        get "/api/v1/collections/search", params: bad_handle_params, headers: valid_session
+        get '/api/v1/collections/search', params: bad_handle_params, headers: valid_session
       end
 
       it 'returns error message as JSON' do
         expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to match(hash_including("error" => "Could not find all the specified collection handles"))
+        expect(JSON.parse(response.body)).to match(
+          hash_including('error' => 'Could not find all the specified collection handles')
+        )
       end
     end
   end


### PR DESCRIPTION
This PR (into the `release/sort_by_changed_29` branch) sets the stage for sorting by `changed` instead of `created`. It sets `changed` to equal `created` in cases where a `changed` value is nil (or an empty string), but a `changed` value is present.

It also includes quite a bit of spec cleanup. `spec/requests/api/v1/collections_spec.rb` could still use some more work, but at a certain point I had to stop and move on with my actual story. :) (Note also that I left a number of the hashes with string keys in place, to be consistent with the values returned by the parsed JSON.)