### PR TITLE
SRCH-656 stop requiring content or description

### DIFF
--- a/app/controllers/api/v1/documents.rb
+++ b/app/controllers/api/v1/documents.rb
@@ -86,9 +86,8 @@ module API
                    type: String,
                    allow_blank: false,
                    desc: "Comma-separated list of category tags"
-
-          at_least_one_of :content, :description
         end
+
         post do
           Document.index_name = Document.index_namespace(@collection_handle)
           id = params.delete(:document_id)

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -163,23 +163,6 @@ describe API::V1::Documents, elasticsearch: true  do
       end
     end
 
-    context 'missing at least one of two required parameters' do
-      before do
-        invalid_params = { document_id: 'a1234',
-                           title:       'my title',
-                           path:        'http://www.gov.gov/goo.html',
-                           created:      '2013-02-27T10:00:00Z' }
-        api_post invalid_params, valid_session
-      end
-
-      it 'returns failure message as JSON' do
-        expect(response.status).to eq(400)
-        expect(JSON.parse(response.body))
-            .to match(hash_including('status' => 400,
-                                     'developer_message' => 'content, description are missing, at least one parameter must be provided'))
-      end
-    end
-
     context 'a required parameter is empty/blank' do
       before do
         invalid_params = valid_params.merge({ 'title' => ' ' })


### PR DESCRIPTION
This PR allows I14y documents to be created with only a title, rather than requiring a title plus either content or a description. This will allow us to index pages that lack both parseable content and metadata.