### PR TITLE
SRCH-706 do not return suggestion if search returns results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,11 @@ workflows:
   build_and_test:
     jobs:
       - build:
+          name: 'ruby 2.3.8'
           ruby_version: 2.3.8
       - build:
+          name: 'ruby 2.5.5'
           ruby_version: 2.5.5
       - build:
-          ruby_version: 2.6.2
+          name: 'ruby 2.6.3'
+          ruby_version: 2.6.3

--- a/app/classes/document_search_results.rb
+++ b/app/classes/document_search_results.rb
@@ -5,7 +5,7 @@ class DocumentSearchResults
     @total = result['hits']['total']
     @offset = offset
     @results = extract_hits(result['hits']['hits'])
-    @suggestion = extract_suggestion(result['suggest']['suggestion']) if result['suggest']
+    @suggestion = extract_suggestion(result['suggest'])
   end
 
   def override_suggestion(suggestion)
@@ -14,11 +14,11 @@ class DocumentSearchResults
 
   private
 
-  def extract_suggestion(suggestions)
-    suggestion = suggestions.first['options'].first
-    suggestion.delete('score')
-    suggestion
-  rescue NoMethodError => e
+  def extract_suggestion(suggest)
+    return unless suggest && total.zero?
+
+    suggest['suggestion'].first['options'].first.except('score')
+  rescue NoMethodError
     nil
   end
 
@@ -34,7 +34,7 @@ class DocumentSearchResults
         end
       end
       %w(created_at created changed updated_at updated).each do |date|
-        source[date] = DateTime.parse(source[date]).utc.to_s if source[date].present?
+        source[date] = Time.parse(source[date]).utc.to_s if source[date].present?
       end
       source
     end

--- a/spec/classes/document_search_spec.rb
+++ b/spec/classes/document_search_spec.rb
@@ -599,6 +599,20 @@ describe DocumentSearch do
     end
   end
 
+  context 'when a search term yields results as well as a suggestion' do
+    let(:query) { 'fsands' }
+
+    before do
+      document_create(common_params.merge(content: 'FSAND'))
+      document_create(common_params.merge(content: 'fund'))
+      document_create(common_params.merge(content: 'fraud'))
+    end
+
+    it 'does not return a suggestion' do
+      expect(document_search_results.suggestion).to be nil
+    end
+  end
+
   describe "searching by exact phrase" do
     let(:query) { '"amazing spiderman"' }
 


### PR DESCRIPTION
This PR prevents suggestions from being returned when valid results are found for a query. It also resolves a couple of Rubocop offenses:
```
app/classes/document_search_results.rb:21:27: W: Lint/UselessAssignment: Useless assignment to variable - error.
  rescue NoMethodError => error
                          ^^^^^
app/classes/document_search_results.rb:37:24: C: Style/DateTime: Prefer Date or Time over DateTime.
        source[date] = DateTime.parse(source[date]).utc.to_s if source[date].present?
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```