### PR TITLE
SRCH-791 fix date sorting spec

### DIFF
--- a/spec/classes/document_search_spec.rb
+++ b/spec/classes/document_search_spec.rb
@@ -319,6 +319,7 @@ describe DocumentSearch do
       Document.create(common_params.merge(changed: 2.month.ago,
                                           path: 'http://www.agency.gov/2months.html'))
       Document.create(common_params.merge(changed: nil,
+                                          created: nil,
                                           path: 'http://www.agency.gov/nodate.html'))
       Document.create(common_params.merge(changed: 6.months.ago,
                                           path: 'http://www.agency.gov/6months.html'))


### PR DESCRIPTION
This PR fixes the broken "sorting by date" spec on master. The issue was that the change I made to set `changed` to the value of `created` (https://github.com/GSA/i14y/commit/135f9192ef5a2fda22b0760f771b2107cf677e6c) meant that the doc that was supposed to have no value for `changed` was having that value set to its `created` date. The fix is to nullify `created` in the test doc.