### PR TITLE
SRCH-811 remove ruby 2.3 from test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,6 @@ workflows:
   build_and_test:
     jobs:
       - build:
-          name: 'ruby 2.3.8'
-          ruby_version: 2.3.8
-      - build:
           name: 'ruby 2.5.5'
           ruby_version: 2.5.5
       - build:


### PR DESCRIPTION
@peggles2 , this removes 2.3 from the test matrix on CirclCi. Tests will be run against ruby 2.5 and 2.6.