### PR TITLE
SRCH-1031 dockerizing local test procedure

### DIFF
--- a/Dockerfile.elasticsearch
+++ b/Dockerfile.elasticsearch
@@ -1,0 +1,6 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+RUN elasticsearch-plugin install analysis-kuromoji
+RUN elasticsearch-plugin install analysis-icu
+RUN elasticsearch-plugin install analysis-smartcn
+
+

--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -1,0 +1,18 @@
+FROM ruby:2.5.5
+RUN apt-get update -qq && apt-get install -y nodejs netcat
+RUN mkdir /myapp
+WORKDIR /myapp
+COPY Gemfile /myapp/Gemfile
+COPY Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+COPY . /myapp
+COPY config/secrets_example.yml config/secrets.yml
+
+# Add a script to be executed every time the container starts.
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+#EXPOSE 3000
+
+# Start the main process.
+CMD ["bundle", "exec", "rake"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ i14y
 Search engine for agencies' published content
 
 ## Dependencies/Prerequisistes
+
+To run locally follow these instructions.  You may skip these instructions if running in docker containers and jump to the [tests section](#tsts)
 - Install Elasticsearch 5.6+:
 ```
 $ brew search elasticsearch
@@ -69,9 +71,11 @@ $ curl localhost:9256
 If you ever want to start from scratch with your indexes/templates, you can clear everything out:
 `bundle exec rake i14y:clear_all`
 
-## Tests
+## <a name="tests"></a>Tests
 
 `bundle exec rake`
+
+To test inside docker containers simply run `docker-compose up --build rails`
 
 ## Deployment
 

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,7 +1,7 @@
 yaml = YAML.load_file("#{Rails.root}/config/elasticsearch.yml").presence
 
 Elasticsearch::Persistence.client = Elasticsearch::Client.new(log: Rails.env.development?,
-                                                              hosts: yaml['hosts'],
+                                                              hosts: ENV['elastichost'] || yaml['hosts'],
                                                               user: yaml['user'],
                                                               password: yaml['password'],
                                                               randomize_hosts: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+
+  elasticsearch:
+    build:
+      context: ./
+      dockerfile: Dockerfile.elasticsearch
+    environment:
+      discovery.type: single-node
+      cluster.name: elasticsearch_56
+      node.name: "es56"
+    ports:
+      - '9256:9200'
+
+  rails:
+    build:
+      context: ./
+      dockerfile: Dockerfile.rails
+    command: ["bundle", "exec", "rake"]
+    entrypoint: ["entrypoint.sh"]
+    # command: ["sleep", "10000"]
+    environment:
+      elastichost: "elasticsearch:9200"
+      ELASTICHOST: "elasticsearch"
+      ELASTICPORT: "9200"
+
+    depends_on:
+      - elasticsearch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Waiting for Elasticsearch..."
+echo $ELASTICHOST
+while ! nc -z $ELASTICHOST $ELASTICPORT; do
+  sleep 1
+  echo "Elasticsearch Not Found"
+done
+echo "Elasticsearch started"
+
+bundle exec rake i14y:clear_all
+
+bundle exec rake i14y:setup
+
+exec "$@"


### PR DESCRIPTION
added  Elasticsearch and ruby tests to a docker-compose command.  To test pull this branch and run "docker-compose up --build rails"