### PR TITLE
Elasticsearch 6.8 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cors (1.0.5)

--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -142,9 +142,20 @@ class DocumentQuery
 
   def highlight_fields_hash
     {
-      full_text_fields['title'] => { number_of_fragments: 0 },
-      full_text_fields['description'] => { fragment_size: 75, number_of_fragments: 2 },
-      full_text_fields['content'] => { fragment_size: 75, number_of_fragments: 2 },
+      full_text_fields['title'] => {
+        number_of_fragments: 0,
+        type: 'fvh'
+      },
+      full_text_fields['description'] => {
+        fragment_size: 75,
+        number_of_fragments: 2,
+        type: 'fvh'
+      },
+      full_text_fields['content'] => {
+        fragment_size: 75,
+        number_of_fragments: 2,
+        type: 'fvh'
+      }
     }
   end
 

--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -186,7 +186,7 @@ class Documents
   def bigrams(json)
     json.bigrams do
       json.analyzer "bigrams_analyzer"
-      json.type "string"
+      json.type "text"
     end
   end
 
@@ -253,7 +253,7 @@ class Documents
       json.child! do
         json.set! locale do
           json.match "*_#{locale}"
-          json.match_mapping_type "string"
+          json.match_mapping_type "text"
           json.mapping do
             json.analyzer "#{locale}_analyzer"
             json.type "text"

--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -253,7 +253,7 @@ class Documents
       json.child! do
         json.set! locale do
           json.match "*_#{locale}"
-          json.match_mapping_type "text"
+          json.match_mapping_type "string"
           json.mapping do
             json.analyzer "#{locale}_analyzer"
             json.type "text"


### PR DESCRIPTION
This PR contains several changes designed to make I14y forward compatible with Elasticsearch 6.8. 