### PR TITLE
SRCH-1233 specify highlighter type

### DIFF
--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -142,9 +142,20 @@ class DocumentQuery
 
   def highlight_fields_hash
     {
-      full_text_fields['title'] => { number_of_fragments: 0 },
-      full_text_fields['description'] => { fragment_size: 75, number_of_fragments: 2 },
-      full_text_fields['content'] => { fragment_size: 75, number_of_fragments: 2 },
+      full_text_fields['title'] => {
+        number_of_fragments: 0,
+        type: 'fvh'
+      },
+      full_text_fields['description'] => {
+        fragment_size: 75,
+        number_of_fragments: 2,
+        type: 'fvh'
+      },
+      full_text_fields['content'] => {
+        fragment_size: 75,
+        number_of_fragments: 2,
+        type: 'fvh'
+      },
     }
   end
 

--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -155,7 +155,7 @@ class DocumentQuery
         fragment_size: 75,
         number_of_fragments: 2,
         type: 'fvh'
-      },
+      }
     }
   end
 


### PR DESCRIPTION
This PR specifies the `fvh` highlighter type ("fast vector highlighter"), which is a forward-compatible change intended to preserve the existing highlighter behavior when we upgrade to Elasticsearch 6.8.