### PR TITLE
match 'string' mapping type

### DIFF
--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -253,7 +253,7 @@ class Documents
       json.child! do
         json.set! locale do
           json.match "*_#{locale}"
-          json.match_mapping_type "text"
+          json.match_mapping_type "string"
           json.mapping do
             json.analyzer "#{locale}_analyzer"
             json.type "text"


### PR DESCRIPTION
@peggles2 , this is a follow-up tweak to https://github.com/GSA/i14y/pull/108. I made two errors with that PR: 1) I didn't rebuild the templates before running my local specs, so my specs were passing erroneously, 2) I didn't realize the the branch had failed on CircleCi, which was hidden because the failure happened before the PR was opened. Oy. 

Anyway, this change is due to the fact that while `string` types are deprecated for field mappings,  `string` is still used in dynamic templates to specify what should happen with generic strings: https://www.elastic.co/guide/en/elasticsearch/reference/master/dynamic-templates.html#match-mapping-type