### PR TITLE
Release 1.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cors (1.0.5)

--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -142,9 +142,20 @@ class DocumentQuery
 
   def highlight_fields_hash
     {
-      full_text_fields['title'] => { number_of_fragments: 0 },
-      full_text_fields['description'] => { fragment_size: 75, number_of_fragments: 2 },
-      full_text_fields['content'] => { fragment_size: 75, number_of_fragments: 2 },
+      full_text_fields['title'] => {
+        number_of_fragments: 0,
+        type: 'fvh'
+      },
+      full_text_fields['description'] => {
+        fragment_size: 75,
+        number_of_fragments: 2,
+        type: 'fvh'
+      },
+      full_text_fields['content'] => {
+        fragment_size: 75,
+        number_of_fragments: 2,
+        type: 'fvh'
+      }
     }
   end
 

--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -186,7 +186,7 @@ class Documents
   def bigrams(json)
     json.bigrams do
       json.analyzer "bigrams_analyzer"
-      json.type "string"
+      json.type "text"
     end
   end
 


### PR DESCRIPTION
[SRCH-1230] - resolve search errors: 'no mapping found for field [bigrams]'
[SRCH-1233] - specify 'fvh' as highlighter type
[SRCH-1149] -update rack in i14y to 2.0.8+