### PR TITLE
Release 1.3.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     net-ssh (4.2.0)
     newrelic_rpm (4.5.0.337)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     parallel (1.12.1)
     parser (2.5.1.2)


### PR DESCRIPTION
[SRCH-1312] - Update Nokogiri security vulnerability for i14y.gov