### PR TITLE
Release 1.3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             - ~/elasticsearch-6.8.6
       - run:
           name: Run Elasticsearch in background
-          command: ~/elasticsearch-$ES_VER/bin/elasticsearch -E http.port=9268
+          command: ~/elasticsearch-$ES_VER/bin/elasticsearch -E http.port=9200
           background: true
       - restore_cache:
            key: bundle-{{ checksum "Gemfile.lock" }}
@@ -57,7 +57,7 @@ jobs:
             chmod +x ./cc-test-reporter
       - run:
           name: Waiting for Elasticsearch
-          command: dockerize --wait http://localhost:9268 -timeout 1m
+          command: dockerize --wait http://localhost:9200 -timeout 1m
       - run:
           name: RSpec
           environment:

--- a/Dockerfile.elasticsearch
+++ b/Dockerfile.elasticsearch
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.9
+RUN elasticsearch-plugin install analysis-kuromoji
+RUN elasticsearch-plugin install analysis-icu
+RUN elasticsearch-plugin install analysis-smartcn

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       pry (>= 0.10.4)
     puma (4.3.5)
       nio4r (~> 2.0)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cors (1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    puma (4.3.3)
+    puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.2)
     rack-accept (0.4.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,6 +1,6 @@
 # This file is overwritten by Chef during a deploy. Any production
 # changes should be made in the cookbooks.
 hosts:
-  - localhost:9268
+  - localhost:9200
 user: elastic
 password: changeme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  elasticsearch:
+    build:
+      context: ./
+      dockerfile: Dockerfile.elasticsearch
+    environment:
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:6.8.9
+    depends_on:
+      - elasticsearch
+    ports:
+      - 5601:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+
+volumes:
+  es_data:


### PR DESCRIPTION
[SRCH-1031] - run Elasticsearch 6.8 using Docker
[SRCH-1541] - upgrade vulnerable i14y gems