### PR TITLE
SRCH-1717 remove references to deprecated _all field

### DIFF
--- a/app/templates/collections.rb
+++ b/app/templates/collections.rb
@@ -7,7 +7,6 @@ class Collections
       json.mappings do
         json.collection do
           dynamic_templates(json)
-          json._all { json.enabled false }
         end
       end
     end

--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -23,7 +23,6 @@ class Documents
         json.document do
           dynamic_templates(json)
           properties(json)
-          json._all { json.enabled false }
         end
       end
     end


### PR DESCRIPTION
This is the first of several minor tweaks resolving deprecation warnings, in preparation of our upgrade to Elasticsearch 7.x.