### PR TITLE
SRCH-1716 use fractional weight to demote by extension

### DIFF
--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -105,7 +105,7 @@ class DocumentQuery
             extension: %w(doc docx pdf ppt pptx xls xlsx)
           }
         },
-        weight: -3
+        weight: '.75'
       },
 
       # Prefer documents that have been clicked more often


### PR DESCRIPTION
Negative weights in function scores are disallowed in Elasticsearch 7. This updates our function score to use a fractional value instead, which accomplishes the desired demotion of documents with certain filetypes.