### PR TITLE
SRCH-1728 change 'template' to 'index_patterns'

### DIFF
--- a/app/templates/collections.rb
+++ b/app/templates/collections.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class Collections
   include Templatable
 
   def body
     Jbuilder.encode do |json|
-      json.template "*-#{I14y::APP_NAME}-collections-*"
+      json.index_patterns "*-#{I14y::APP_NAME}-collections-*"
       json.mappings do
         json.collection do
           dynamic_templates(json)

--- a/app/templates/documents.rb
+++ b/app/templates/documents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Documents
   include Templatable
   LIGHT_STEMMERS = { fr: "french", de: "german", es: "spanish", it: "italian", pt: "portuguese" }
@@ -10,7 +12,7 @@ class Documents
 
   def body
     Jbuilder.encode do |json|
-      json.template "*-#{I14y::APP_NAME}-documents-*"
+      json.index_patterns "*-#{I14y::APP_NAME}-documents-*"
       json.settings do
         json.analysis do
           char_filter(json)


### PR DESCRIPTION
This resolves an ES 7 deprecation:
```
Deprecated field [template] used, replaced by [index_patterns] 
```