### PR TITLE
SRCH-1754 update Elasticsearch initializer & client

### DIFF
--- a/app/classes/document_search.rb
+++ b/app/classes/document_search.rb
@@ -34,7 +34,7 @@ class DocumentSearch
   def execute_client_search
     params = { index: indices, body: doc_query.body, from: offset, size: size }
     Rails.logger.debug "Query: *****\n#{doc_query.body.to_json}\n*****"
-    result = Elasticsearch::Persistence.client.search(params)
+    result = ES.client.search(params)
     DocumentSearchResults.new(result, offset)
   end
 end

--- a/app/controllers/api/v1/collections.rb
+++ b/app/controllers/api/v1/collections.rb
@@ -49,8 +49,10 @@ module API
           error!(collection.errors.messages, 400) unless collection.valid?
           es_documents_index_name = [Document.index_namespace(handle), 'v1'].join('-')
           Document.create_index!(index: es_documents_index_name)
-          Elasticsearch::Persistence.client.indices.put_alias index: es_documents_index_name,
-                                                              name: Document.index_namespace(handle)
+          ES.client.indices.put_alias(
+            index: es_documents_index_name,
+            name: Document.index_namespace(handle)
+          )
           ok("Your collection was successfully created.")
         end
 
@@ -60,7 +62,9 @@ module API
           handle = params.delete(:handle)
           collection = Collection.find(handle)
           error!(collection.errors.messages, 400) unless collection.destroy
-          Elasticsearch::Persistence.client.indices.delete(index: [Document.index_namespace(handle), '*'].join('-'))
+          ES.client.indices.delete(
+            index: [Document.index_namespace(handle), '*'].join('-')
+          )
           ok("Your collection was successfully deleted.")
         end
 

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,16 +1,24 @@
-yaml = YAML.load_file("#{Rails.root}/config/elasticsearch.yml").presence
+# frozen_string_literal: true
 
-Elasticsearch::Persistence.client = Elasticsearch::Client.new(log: Rails.env.development?,
-                                                              hosts: yaml['hosts'],
-                                                              user: yaml['user'],
-                                                              password: yaml['password'],
-                                                              randomize_hosts: true,
-                                                              retry_on_failure: true,
-                                                              reload_connections: true)
+module ES
+  CONFIG = YAML.load_file("#{Rails.root}/config/elasticsearch.yml").presence.freeze
+
+  def self.client
+    Elasticsearch::Client.new(log: Rails.env.development?,
+                              hosts: CONFIG['hosts'],
+                              user: CONFIG['user'],
+                              password: CONFIG['password'],
+                              randomize_hosts: true,
+                              retry_on_failure: true,
+                              reload_connections: true)
+  end
+end
 
 if Rails.env.development?
   logger = ActiveSupport::Logger.new(STDERR)
   logger.level = Logger::DEBUG
   logger.formatter = proc { |_s, _d, _p, m| "\e[2m#{m}\n\e[0m" }
-  Elasticsearch::Persistence.client.transport.logger = logger
+  ES.client.transport.logger = logger
 end
+
+Elasticsearch::Persistence.client = ES.client

--- a/lib/tasks/i14y.rake
+++ b/lib/tasks/i14y.rake
@@ -5,14 +5,17 @@ namespace :i14y do
       entity_name = File.basename(template_generator, '.rb')
       klass = entity_name.camelize.constantize
       template_generator = klass.new
-      Elasticsearch::Persistence.client.indices.put_template(name: entity_name,
-                                                             body: template_generator.body,
-                                                             order: 0,
-                                                             create: true)
+      ES.client.indices.put_template(name: entity_name,
+                                     body: template_generator.body,
+                                     order: 0,
+                                     create: true)
     end
     es_collections_index_name = [Collection.index_namespace, 'v1'].join('-')
     Collection.create_index!(index: es_collections_index_name)
-    Elasticsearch::Persistence.client.indices.put_alias index: es_collections_index_name, name: Collection.index_name
+    ES.client.indices.put_alias(
+      index: es_collections_index_name,
+      name: Collection.index_name
+    )
   end
 
   desc "Copies data from one version of the i14y index to the next (e.g., collections, documents) and updates the alias"
@@ -21,12 +24,12 @@ namespace :i14y do
     persistence_model_klass = entity_name.singularize.camelize.constantize
     klass = entity_name.camelize.constantize
     template_generator = klass.new
-    Elasticsearch::Persistence.client.indices.put_template(name: entity_name,
-                                                           body: template_generator.body,
-                                                           order: 0)
+    ES.client.indices.put_template(name: entity_name,
+                                   body: template_generator.body,
+                                   order: 0)
 
     wildcard = [persistence_model_klass.index_namespace, '*'].join
-    aliases = Elasticsearch::Persistence.client.indices.get_alias(name: wildcard)
+    aliases = ES.client.indices.get_alias(name: wildcard)
     aliases.each do |old_es_index_name, alias_names|
       alias_name = alias_names['aliases'].keys.first
       persistence_model_klass.index_name = old_es_index_name
@@ -35,7 +38,7 @@ namespace :i14y do
       persistence_model_klass.create_index!(index: new_es_index_name)
       persistence_model_klass.index_name = new_es_index_name
       since_timestamp = Time.now
-      host_hash = Elasticsearch::Persistence.client.transport.hosts.first
+      host_hash = ES.client.transport.hosts.first
       base_url = "#{host_hash[:protocol]}://#{host_hash[:host]}:#{host_hash[:port]}/"
       old_es_index_url = base_url + old_es_index_name
       new_es_index_url = base_url + new_es_index_name
@@ -43,7 +46,7 @@ namespace :i14y do
       move_alias(alias_name, old_es_index_name, new_es_index_name)
       stream2es(old_es_index_url, new_es_index_url, since_timestamp)
       puts "New #{new_es_index_name} index now contains #{persistence_model_klass.count} #{entity_name}"
-      Elasticsearch::Persistence.client.indices.delete(index: old_es_index_name)
+      ES.client.indices.delete(index: old_es_index_name)
     end
   end
 
@@ -51,9 +54,9 @@ namespace :i14y do
   task clear_all: :environment do
     Dir[Rails.root.join('app', 'templates', '*.rb')].each do |template_generator|
       entity_name = File.basename(template_generator, '.rb')
-      Elasticsearch::Persistence.client.indices.delete_template(name: entity_name) rescue Elasticsearch::Transport::Transport::Errors::NotFound
+      ES.client.indices.delete_template(name: entity_name) rescue Elasticsearch::Transport::Transport::Errors::NotFound
     end
-    Elasticsearch::Persistence.client.indices.delete(index: [Rails.env, I14y::APP_NAME, '*'].join('-'))
+    ES.client.indices.delete(index: [Rails.env, I14y::APP_NAME, '*'].join('-'))
   end
 
   def next_version(index_name)
@@ -77,7 +80,7 @@ namespace :i14y do
                                 { remove: { index: old_index_name, alias: alias_name } },
                                 { add: { index: new_index_name, alias: alias_name } }
                               ] } }
-    Elasticsearch::Persistence.client.indices.update_aliases(update_aliases_hash)
+    ES.client.indices.update_aliases(update_aliases_hash)
   end
 
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -18,18 +18,20 @@ describe Document do
 
   before(:all) do
     handle = 'test_index'
-    Elasticsearch::Persistence.client.indices.delete(
+    ES.client.indices.delete(
       index: [Document.index_namespace(handle), '*'].join('-')
     )
     es_documents_index_name = [Document.index_namespace(handle), 'v1'].join('-')
     Document.create_index!(index: es_documents_index_name)
-    Elasticsearch::Persistence.client.indices.put_alias index: es_documents_index_name,
-                                                        name: Document.index_namespace(handle)
+    ES.client.indices.put_alias(
+      index: es_documents_index_name,
+      name: Document.index_namespace(handle)
+    )
     Document.index_name = Document.index_namespace(handle)
   end
 
   after(:all) do
-    Elasticsearch::Persistence.client.indices.delete(
+    ES.client.indices.delete(
       index: [Document.index_namespace('test_index'), '*'].join('-')
     )
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'test_services'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -28,11 +31,11 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.include DocumentCrud
+  config.include TestServices
 
   config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
-    require 'test_services'
     TestServices::delete_es_indexes
     TestServices::create_es_indexes
   end
@@ -54,6 +57,6 @@ RSpec.configure do |config|
   end
 
   config.after :each, elasticsearch: true do
-    Elasticsearch::Persistence.client.indices.delete index: '*documents*'
+    ES.client.indices.delete index: '*documents*'
   end
 end

--- a/spec/requests/api/v1/collections_spec.rb
+++ b/spec/requests/api/v1/collections_spec.rb
@@ -26,11 +26,7 @@ describe API::V1::Collections do
   describe 'POST /api/v1/collections' do
     context 'success case' do
       before do
-        Elasticsearch::Persistence.client.delete_by_query(
-          index: Collection.index_name,
-          q: '*:*',
-          conflicts: 'proceed'
-        )
+        clear_index(collections_index_name)
         post '/api/v1/collections', params: valid_params, headers: valid_session
       end
 
@@ -125,7 +121,7 @@ describe API::V1::Collections do
   describe 'DELETE /api/v1/collections/{handle}' do
     context 'success case' do
       before do
-        Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(collections_index_name)
         Collection.create(_id: 'agency_blogs', token: 'secret')
         delete '/api/v1/collections/agency_blogs', headers: valid_session
       end
@@ -150,10 +146,10 @@ describe API::V1::Collections do
   describe 'GET /api/v1/collections/{handle}' do
     context 'success case' do
       before do
-        Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(collections_index_name)
         post '/api/v1/collections', params: valid_params, headers: valid_session
         Document.index_name = Document.index_namespace('agency_blogs')
-        Elasticsearch::Persistence.client.delete_by_query index: Document.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(Document.index_name)
       end
 
       let(:datetime) { DateTime.now.utc }
@@ -202,10 +198,10 @@ describe API::V1::Collections do
   describe 'GET /api/v1/collections/search' do
     context 'success case' do
       before do
-        Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(collections_index_name)
         post '/api/v1/collections', params: valid_params, headers: valid_session
         Document.index_name = Document.index_namespace('agency_blogs')
-        Elasticsearch::Persistence.client.delete_by_query index: Document.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(Document.index_name)
       end
 
       let(:datetime) { DateTime.now.utc.to_s }
@@ -300,10 +296,10 @@ describe API::V1::Collections do
 
     context 'no results' do
       before do
-        Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(collections_index_name)
         post '/api/v1/collections', params: valid_params, headers: valid_session
         Document.index_name = Document.index_namespace('agency_blogs')
-        Elasticsearch::Persistence.client.delete_by_query index: Document.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(Document.index_name)
       end
 
       it 'returns JSON no hits results' do
@@ -343,7 +339,7 @@ describe API::V1::Collections do
       end
 
       before do
-        Elasticsearch::Persistence.client.delete_by_query index: Collection.index_name, q: '*:*', conflicts: 'proceed'
+        clear_index(collections_index_name)
         Collection.create(_id: 'agency_blogs', token: 'secret')
         get '/api/v1/collections/search', params: bad_handle_params, headers: valid_session
       end

--- a/spec/test_services.rb
+++ b/spec/test_services.rb
@@ -1,13 +1,29 @@
+# frozen_string_literal: true
+
 module TestServices
   module_function
 
   def create_es_indexes
-    es_collections_index_name = [Rails.env, I14y::APP_NAME, 'collections', 'v1'].join('-')
-    Collection.create_index!(index: es_collections_index_name)
-    Elasticsearch::Persistence.client.indices.put_alias index: es_collections_index_name, name: Collection.index_name
+    Collection.create_index!(index: collections_index_name)
+    ES.client.indices.put_alias(
+      index: collections_index_name,
+      name: Collection.index_name
+    )
   end
 
   def delete_es_indexes
-    Elasticsearch::Persistence.client.indices.delete(index: [Rails.env, I14y::APP_NAME, '*'].join('-'))
+    ES.client.indices.delete(index: [Rails.env, I14y::APP_NAME, '*'].join('-'))
+  end
+
+  def clear_index(index_name)
+    ES.client.delete_by_query(
+      index: index_name,
+      q: '*:*',
+      conflicts: 'proceed'
+    )
+  end
+
+  def collections_index_name
+    [Rails.env, I14y::APP_NAME, 'collections', 'v1'].join('-')
   end
 end


### PR DESCRIPTION
This is the first of several PRs into the `release/elasticsearch_gems_1727` branch. I've broken up the changes largely to simplify the review process. This PR updates the Elasticsearch client initializer to avoid using the `Elasticsearch::Persistence.client` method, which is deprecated in the next version of the `elasticsearch-persistence` gem. That will still be in temporary use to set the persistence client (`Elasticsearch::Persistence.client = ES.client`) until I update the gems.

It also adds a couple of test helpers to DRY up the specs.