### PR TITLE
SRCH-1743 create repository classes

### DIFF
--- a/app/repositories/collection_repository.rb
+++ b/app/repositories/collection_repository.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CollectionRepository
+  include Elasticsearch::Persistence::Repository
+
+  klass Collection
+  client ES.client
+end

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DocumentRepository
+  include Elasticsearch::Persistence::Repository
+
+  klass Document
+  client ES.client
+end

--- a/spec/repositories/collection_repository_spec.rb
+++ b/spec/repositories/collection_repository_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CollectionRepository do
+  subject(:repository) { described_class.new }
+
+  it_behaves_like 'a repository'
+
+  describe '.klass' do
+    subject(:klass) { described_class.klass }
+
+    it { is_expected.to eq(Collection) }
+  end
+end

--- a/spec/repositories/document_repository_spec.rb
+++ b/spec/repositories/document_repository_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DocumentRepository do
+  subject(:repository) { described_class.new }
+
+  it_behaves_like 'a repository'
+
+  describe '.klass' do
+    subject(:klass) { described_class.klass }
+
+    it { is_expected.to eq(Document) }
+  end
+end

--- a/spec/support/shared_examples/repository_behavior.rb
+++ b/spec/support/shared_examples/repository_behavior.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+shared_examples_for 'a repository' do
+  describe 'serialization' do
+    subject(:serialize) { repository.serialize(klass_instance) }
+
+    let(:klass_instance) { repository.klass.new }
+
+    it { is_expected.to be_a Hash }
+  end
+
+  it 'can connect to Elasticsearch' do
+    expect(repository.client.ping).to be(true)
+  end
+end


### PR DESCRIPTION
This PR sets up the new Repository classes, which will subsequently be used to store the corresponding `Document` and `Collection` instances. The goal is to decouple the model logic from the persistence logic. A detailed explanation of why and how these changes are being made is in:
https://www.elastic.co/blog/activerecord-to-repository-changing-persistence-patterns-with-the-elasticsearch-rails-gem

The follow-up commits will build on these repository classes, moving the persistence, serialization, and search logic out of the `Document` and `Collection` classes and into the repository classes. (I toyed with retaining the `elasticsearch-model` gem, which offers ActiveRecord-y persistence to POROs, but ultimately I agree w/ the recommendation to decouple the model/ persistence logic. It won't surprise me at all if the `elasticsearch-model` gem is deprecated in the future, which also makes this a safer route.)

