### PR TITLE
SRCH-1767 refactor serialization specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ capybara-*.html
 .idea
 
 .rspec
+.rspec-local
 /log
 /tmp
 /db/*.sqlite3

--- a/spec/lib/serde_spec.rb
+++ b/spec/lib/serde_spec.rb
@@ -37,6 +37,31 @@ describe Serde do
         }
       )
     end
+
+    context 'when language fields contain HTML/CSS' do
+      let(:html) do
+        <<~HTML
+          <div style="height: 100px; width: 100px;"></div>
+          <p>hello & goodbye!</p>
+        HTML
+      end
+
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: '<b><a href="http://foo.com/">foo</a></b><img src="bar.jpg">',
+          description: html,
+          content: "this <b>is</b> <a href='http://gov.gov/url.html'>html</a>"
+        )
+      end
+
+      it 'sanitizes the language fields' do
+        expect(serialize_hash).to match(hash_including(
+          title_en: 'foo',
+          description_en: 'hello & goodbye!',
+          content_en: 'this is html'
+        ))
+      end
+    end
   end
 
   describe '.deserialize_hash' do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -14,6 +14,15 @@ describe Collection do
 
   it { is_expected.to be_valid }
 
+  describe 'attributes' do
+    it do
+      is_expected.to have_attributes(
+        token: 'secret',
+        id: 'agency_blogs'
+      )
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:token) }
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -7,77 +7,37 @@ describe Document do
       language: 'en',
       path: 'http://www.agency.gov/page1.html',
       title: 'My Title',
-      created: DateTime.now,
-      changed: DateTime.now,
+      created: DateTime.new(2020, 1, 1),
+      changed: DateTime.new(2020, 1, 2),
       description: 'My Description',
       content: 'some content',
       promote: true,
-      tags: 'this,that'
+      tags: 'this,that',
+      click_count: 5
     }
   end
 
-  before(:all) do
-    handle = 'test_index'
-    Elasticsearch::Persistence.client.indices.delete(
-      index: [Document.index_namespace(handle), '*'].join('-')
-    )
-    es_documents_index_name = [Document.index_namespace(handle), 'v1'].join('-')
-    Document.create_index!(index: es_documents_index_name)
-    Elasticsearch::Persistence.client.indices.put_alias index: es_documents_index_name,
-                                                        name: Document.index_namespace(handle)
-    Document.index_name = Document.index_namespace(handle)
-  end
+  describe 'attributes' do
+    subject(:document) { described_class.new(valid_params) }
 
-  after(:all) do
-    Elasticsearch::Persistence.client.indices.delete(
-      index: [Document.index_namespace('test_index'), '*'].join('-')
-    )
+    it do
+      is_expected.to have_attributes(
+        language: 'en',
+        path: 'http://www.agency.gov/page1.html',
+        title: 'My Title',
+        created: DateTime.new(2020, 1, 1),
+        changed: DateTime.new(2020, 1, 2),
+        description: 'My Description',
+        content: 'some content',
+        promote: true,
+        tags: 'this,that',
+        click_count: 5
+      )
+    end
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:path) }
     it { is_expected.to validate_presence_of(:language) }
-  end
-
-  describe '.create' do
-    context 'when language fields contain HTML/CSS and HTML entities' do
-      let(:html) do
-        <<~HTML
-          <div style="height: 100px; width: 100px;"></div>
-          <p>hello & goodbye!</p>
-        HTML
-      end
-
-      before do
-        Document.create(_id: 'a123',
-                        language: 'en',
-                        title: '<b><a href="http://foo.com/">foo</a></b><img src="bar.jpg">',
-                        description: html,
-                        created: DateTime.now,
-                        path: 'http://www.agency.gov/page1.html',
-                        content: "this <b>is</b> <a href='http://gov.gov/url.html'>html</a>")
-      end
-
-      it 'sanitizes the language fields' do
-        document = Document.find 'a123'
-        expect(document.title).to eq('foo')
-        expect(document.description).to eq('hello & goodbye!')
-        expect(document.content).to eq('this is html')
-      end
-    end
-
-    context 'when a created value is provided but not changed' do
-      let(:params_without_changed) do
-        valid_params.merge(created: DateTime.now, changed: '')
-      end
-
-      before { Document.create(params_without_changed) }
-
-      it 'sets "changed" to be the same as "created"' do
-        Document.create(params_without_changed)
-        document = Document.find('a123')
-        expect(document.changed).to eq document.created
-      end
-    end
   end
 end

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -70,6 +70,23 @@ describe API::V1::Documents, elasticsearch: true  do
         expect(document.updated_at).to be_an_instance_of(Time)
       end
 
+      context 'when a "created" value is provided but not "changed"' do
+        let(:valid_params) do
+          { document_id: id,
+            title:       'my title',
+            path:        'http://www.gov.gov/goo.html',
+            description: 'my desc',
+            language:    'hy',
+            content:     'my content',
+            created:     '2020-01-01T10:00:00Z' }
+        end
+
+        it 'sets "changed" to be the same as "created"' do
+          document = Document.find(id)
+          expect(document.changed).to eq '2020-01-01T10:00:00Z'
+        end
+      end
+
       it_behaves_like 'a data modifying request made during read-only mode'
     end
 


### PR DESCRIPTION
'lil more spec refactoring. This PR:
- adds `.rspec-local` to `.gitignore`
- moves some of the serialization specs out of the document specs and into the serializer spec
- adds a few minor unit specs for the models
- moves the "created"/"changed" spec to the request spec, to ensure future refactoring doesn't break that specific functionality