### PR TITLE
SRCH-1854 set ID when deserializing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  ruby: circleci/ruby@1.1.2
+
 executors:
   test_executor:
     parameters:
@@ -33,19 +36,16 @@ jobs:
     steps:
       - checkout
       - run: cp -p config/secrets_example.yml config/secrets.yml
-      - restore_cache:
-           key: bundle-{{ checksum "Gemfile.lock" }}
-      - run: gem install bundler:1.17.3
-      - run: bundle install --path vendor/bundle
-      - save_cache:
-          key: bundle-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/app/vendor/bundle
+      # Install gems with Bundler
+      - ruby/install-deps
       - run:
           name: Setup Code Climate test-reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
+      - run:
+          name: Wait for Elasticsearch
+          command: dockerize -wait tcp://localhost:9200 -timeout 1m
       - run:
           name: RSpec
           environment:

--- a/app/repositories/collection_repository.rb
+++ b/app/repositories/collection_repository.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class CollectionRepository
-  include Elasticsearch::Persistence::Repository
-  include Elasticsearch::Persistence::Repository::DSL
-
-  extend NamespacedIndex
+  include Repository
 
   klass Collection
   client ES.client
   index_name index_namespace
   settings number_of_shards: 1, number_of_replicas: 1
- end
+
+  def deserialize(hash)
+    klass.new(source_hash(hash))
+  end
+end

--- a/app/repositories/concerns/repository.rb
+++ b/app/repositories/concerns/repository.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module Repository
+  extend ActiveSupport::Concern
+
+  included do
+    include Elasticsearch::Persistence::Repository
+    include Elasticsearch::Persistence::Repository::DSL
+
+    extend NamespacedIndex
+
+    client ES.client
+    settings number_of_shards: 1, number_of_replicas: 1
+  end
+
+  def source_hash(hash)
+    hash['_source'].merge(id: hash['_id'])
+  end
+end

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 class DocumentRepository
-  include Elasticsearch::Persistence::Repository
-  include Elasticsearch::Persistence::Repository::DSL
-
-  extend NamespacedIndex
+  include Repository
 
   klass Document
-  client ES.client
-  settings number_of_shards: 1, number_of_replicas: 1
 
   def serialize(document)
     document_hash = ActiveSupport::HashWithIndifferentAccess.new(super)
@@ -16,21 +11,9 @@ class DocumentRepository
   end
 
   def deserialize(hash)
-    doc_hash = hash['_source']
+    doc_hash = source_hash(hash)
     deserialized_hash = Serde.deserialize_hash(doc_hash,
                                                doc_hash['language'])
-
-    document = Document.new deserialized_hash
-    document.instance_variable_set :@_id, hash['_id']
-    document.instance_variable_set :@_index, hash['_index']
-    document.instance_variable_set :@_type, hash['_type']
-    document.instance_variable_set :@_version, hash['_version']
-
-    document.instance_variable_set :@hit, Hashie::Mash.new(
-      hash.except('_index', '_type', '_id', '_version', '_source')
-    )
-
-    document.instance_variable_set(:@persisted, true)
-    document
+    klass.new deserialized_hash
   end
 end

--- a/spec/support/shared_examples/repository_behavior.rb
+++ b/spec/support/shared_examples/repository_behavior.rb
@@ -9,6 +9,24 @@ shared_examples_for 'a repository' do
     it { is_expected.to be_a Hash }
   end
 
+  describe 'deserialization' do
+    subject(:deserialize) { repository.deserialize(hash) }
+
+    # Ensures backwards compatibility with pre-ES 7 documents
+    context 'when the source does not include the id' do
+      let(:hash) do
+        {
+          '_id' => 'a123',
+          '_source' => { }
+        }
+      end
+
+      it 'sets the id on the deserialized object' do
+        expect(deserialize.id).to eq 'a123'
+      end
+    end
+  end
+
   it 'can connect to Elasticsearch' do
     expect(repository.client.ping).to be(true)
   end


### PR DESCRIPTION
This PR ensures that objects instantiated when deserializing from Elasticsearch have the `id` populated from the Elasticsearch `_id` field. This is [recommended](https://www.elastic.co/blog/activerecord-to-repository-changing-persistence-patterns-with-the-elasticsearch-rails-gem) for the Repository pattern, and ensures that our code will work for documents created before our ES7 code changes. Also: 
- move common repository code to a shared concern
- wait for Elasticsearch before running specs in CircleCi
- clean up DocumentRepository#deserialize