### PR TITLE
SRCH-2022 use zeitwerk

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module API
+module Api
   class Base < Grape::API
     rescue_from ReadOnlyAccessControl::DisallowedUpdate do
       message = 'The i14y API is currently in read-only mode.'
@@ -22,6 +22,6 @@ module API
       rack_response({ developer_message: "Something unexpected happened and we've been alerted.", status: 500 }.to_json, 500)
     end
 
-    mount API::V1::Base
+    mount Api::V1::Base
   end
 end

--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -1,8 +1,8 @@
-module API
+module Api
   module V1
     class Base < Grape::API
-      mount API::V1::Documents
-      mount API::V1::Collections
+      mount Api::V1::Documents
+      mount Api::V1::Collections
     end
   end
 end

--- a/app/controllers/api/v1/collections.rb
+++ b/app/controllers/api/v1/collections.rb
@@ -1,4 +1,4 @@
-module API
+module Api
   module V1
     class Collections < Grape::API
       prefix 'api'

--- a/app/controllers/api/v1/documents.rb
+++ b/app/controllers/api/v1/documents.rb
@@ -1,4 +1,4 @@
-module API
+module Api
   module V1
     class Documents < Grape::API
       prefix 'api'

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,9 +40,5 @@ module I14y
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    # Turn on the classic autoloader, because zeitwerk blows
-    # up. SRCH-2022 is the ticket to move i14y to zeitwerk.
-    config.autoloader = :classic
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  mount API::Base => '/'
+  mount Api::Base => '/'
 end

--- a/spec/requests/api/v1/collections_spec.rb
+++ b/spec/requests/api/v1/collections_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe API::V1::Collections do
+describe Api::V1::Collections do
   let(:valid_session) do
     env_secrets = Rails.application.config_for(:secrets)
     credentials = ActionController::HttpAuthentication::Basic.encode_credentials(

--- a/spec/requests/api/v1/documents_spec.rb
+++ b/spec/requests/api/v1/documents_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'uri'
 
-describe API::V1::Documents do
+describe Api::V1::Documents do
   let(:id) { 'some really!weird@id.name' }
   let(:credentials) do
     ActionController::HttpAuthentication::Basic.encode_credentials('test_index',


### PR DESCRIPTION
SRCH-2022 Renamed API module to Api to conform to zeitwerk's preferences.