### PR TITLE
SRCH-3478 i14y support filtering date facet fields

### DIFF
--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -25,9 +25,16 @@ class DocumentQuery
   DATE_AGGREGATION_FIELDS = %i[created
                                changed].freeze
 
-  attr_reader :language, :site_filters, :tags, :ignore_tags, :date_range,
-              :included_sites, :excluded_sites
-  attr_accessor :query, :search
+  attr_reader :date_range,
+              :date_range_created,
+              :excluded_sites,
+              :ignore_tags,
+              :included_sites,
+              :language,
+              :site_filters,
+              :tags
+  attr_accessor :query,
+                :search
 
   def initialize(options)
     @options = options
@@ -35,6 +42,7 @@ class DocumentQuery
     @tags = options[:tags]
     @ignore_tags = options[:ignore_tags]
     @date_range = { gte: @options[:min_timestamp], lt: @options[:max_timestamp] }
+    @date_range_created = { gte: @options[:min_timestamp_created], lt: @options[:max_timestamp_created] }
     @search = Search.new
     @included_sites = []
     @excluded_sites = []
@@ -85,6 +93,10 @@ class DocumentQuery
 
   def timestamp_filters_present?
     @options[:min_timestamp].present? or @options[:max_timestamp].present?
+  end
+
+  def created_timestamp_filters_present?
+    @options[:min_timestamp_created].present? or @options[:max_timestamp_created].present?
   end
 
   def boosted_fields
@@ -299,6 +311,7 @@ class DocumentQuery
                 doc_query.tags.each { |tag| must { term tags: tag } } if doc_query.tags.present?
 
                 must { range changed: doc_query.date_range } if doc_query.timestamp_filters_present?
+                must { range created: doc_query.date_range_created } if doc_query.created_timestamp_filters_present?
 
                 if doc_query.ignore_tags.present?
                   must_not do

--- a/app/controllers/api/v1/collections.rb
+++ b/app/controllers/api/v1/collections.rb
@@ -101,9 +101,19 @@ module Api
           optional :min_timestamp,
                    type: DateTime,
                    allow_blank: false,
-                   desc: 'Return documents that were created at or after this time',
+                   desc: 'Return documents that were changed at or after this time',
                    documentation: { example: '2013-02-27T10:00:00Z' }
           optional :max_timestamp,
+                   type: DateTime,
+                   allow_blank: false,
+                   desc: 'Return documents that were changed before this time',
+                   documentation: { example: '2013-02-27T10:01:00Z' }
+          optional :min_timestamp_created,
+                   type: DateTime,
+                   allow_blank: false,
+                   desc: 'Return documents that were created at or after this time',
+                   documentation: { example: '2013-02-27T10:00:00Z' }
+          optional :max_timestamp_created,
                    type: DateTime,
                    allow_blank: false,
                    desc: 'Return documents that were created before this time',

--- a/spec/classes/document_search_spec.rb
+++ b/spec/classes/document_search_spec.rb
@@ -569,30 +569,110 @@ describe DocumentSearch do
     end
   end
 
-  describe 'filtering on date' do
-    let(:date_filtered_options) do
-      search_options.merge(min_timestamp: 2.weeks.ago,
-                           max_timestamp: 1.day.ago)
-    end
+  context 'when filtering on dates' do
     let(:document_search) { described_class.new(date_filtered_options) }
 
     before do
       create_documents([
-        common_params.merge(changed: 1.month.ago,
-                            path: 'http://www.agency.gov/dir1/page1.html'),
-        common_params.merge(changed: 1.week.ago,
-                            path: 'http://www.agency.gov/dir1/page2.html'),
-        common_params.merge(changed: DateTime.now,
-                            path: 'http://www.agency.gov/dir1/page3.html'),
-        common_params.merge(changed: nil,
-                            path: 'http://www.agency.gov/dir1/page4.html')
-      ])
+                         common_params.merge(changed: 1.month.ago,
+                                             created: nil,
+                                             path: 'http://www.agency.gov/dir1/page1.html'),
+                         common_params.merge(changed: 1.week.ago,
+                                             created: DateTime.now,
+                                             path: 'http://www.agency.gov/dir1/page2.html'),
+                         common_params.merge(changed: DateTime.now,
+                                             created: 1.week.ago,
+                                             path: 'http://www.agency.gov/dir1/page3.html'),
+                         common_params.merge(changed: nil,
+                                             created: 1.month.ago,
+                                             path: 'http://www.agency.gov/dir1/page4.html')
+                       ])
     end
 
-    it 'returns results from only that date range' do
-      expect(document_search_results.total).to eq(1)
-      expect(document_search_results.results.first['path']).
-        to eq('http://www.agency.gov/dir1/page2.html')
+    context 'when filtering on changed date range' do
+      let(:date_filtered_options) do
+        search_options.merge(min_timestamp: 2.weeks.ago,
+                             max_timestamp: 1.day.ago)
+      end
+
+      it 'returns results from only that date range' do
+        expect(document_search_results.total).to eq(1)
+        expect(document_search_results.results.first['path']).
+          to eq('http://www.agency.gov/dir1/page2.html')
+      end
+    end
+
+    context 'when filtering on minimum changed date' do
+      let(:date_filtered_options) { search_options.merge(min_timestamp: 2.weeks.ago) }
+
+      it 'returns results from only after that minimum date' do
+        expect(document_search_results.total).to eq(2)
+        expect(document_search_results.results.map { |r| r['path'] }).
+          to eq(
+            %w[
+              http://www.agency.gov/dir1/page2.html
+              http://www.agency.gov/dir1/page3.html
+            ]
+          )
+      end
+    end
+
+    context 'when filtering on maximum changed date' do
+      let(:date_filtered_options) { search_options.merge(max_timestamp: 1.day.ago) }
+
+      it 'returns results from only before that maxium date' do
+        expect(document_search_results.total).to eq(2)
+        expect(document_search_results.results.map { |r| r['path'] }).
+          to eq(
+            %w[
+              http://www.agency.gov/dir1/page2.html
+              http://www.agency.gov/dir1/page1.html
+            ]
+          )
+      end
+    end
+
+    context 'when filtering on created date range' do
+      let(:date_filtered_options) do
+        search_options.merge(min_timestamp_created: 2.weeks.ago,
+                             max_timestamp_created: 1.day.ago)
+      end
+
+      it 'returns results from only that date range' do
+        expect(document_search_results.total).to eq(1)
+        expect(document_search_results.results.first['path']).
+          to eq('http://www.agency.gov/dir1/page3.html')
+      end
+    end
+
+    context 'when filtering on minimum created date' do
+      let(:date_filtered_options) { search_options.merge(min_timestamp_created: 2.weeks.ago) }
+
+      it 'returns results from only after that minimum date' do
+        expect(document_search_results.total).to eq(2)
+        expect(document_search_results.results.map { |r| r['path'] }).
+          to eq(
+            %w[
+              http://www.agency.gov/dir1/page2.html
+              http://www.agency.gov/dir1/page3.html
+            ]
+          )
+      end
+    end
+
+    context 'when filtering on maximum created date' do
+      let(:date_filtered_options) { search_options.merge(max_timestamp_created: 1.day.ago) }
+
+      it 'returns results from only before that maxium date' do
+        expect(document_search_results.total).to eq(2)
+        expect(document_search_results.results.map { |r| r['path'] }).
+          to eq(
+            %w[
+              http://www.agency.gov/dir1/page3.html
+              http://www.agency.gov/dir1/page4.html
+            ]
+          )
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds (additional) facet field filtering to i14y document querying
- Filtering by `changed` date is already supported via the `min_timestamp` and `max_timestamp` params, this adds additional `min_timestamp_created` and `max_timestamp_created` params to filter by creation dates as well
  - A follow-on ticket is being created to investigate the implications of renaming the existing params for greater clarity now that searchers can filter on both created and changed dates.
- After running a an initial query that returns results, date filters for changed (existing) and created (newly added) may be applied to winnow down those results based on facet field content.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
⚠️ Code Climate is throwing a "too many" methods warning that will need to be approved.  (For reference, there's a ticket in the backlog (SRCH-3234) to disable this check for the searchgov repo, so we may wish to discuss doing the same for this repo.)
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
