### PR TITLE
SRCH-3388 Search newly added i14y fields

### DIFF
--- a/app/classes/document_query.rb
+++ b/app/classes/document_query.rb
@@ -299,8 +299,12 @@ class DocumentQuery
                         end
                       end
 
-                      should { match basename: { operator: 'and', query: doc_query.query } }
-                      should { match tags:     { operator: 'and', query: doc_query.query.downcase } }
+                      should { match(audience: { operator: 'and', query: doc_query.query }) }
+                      should { match(basename: { operator: 'and', query: doc_query.query }) }
+                      should { match(searchgov_custom1: { operator: 'and', query: doc_query.query.downcase }) }
+                      should { match(searchgov_custom2: { operator: 'and', query: doc_query.query.downcase }) }
+                      should { match(searchgov_custom3: { operator: 'and', query: doc_query.query.downcase }) }
+                      should { match(tags: { operator: 'and', query: doc_query.query.downcase }) }
                     end
                   end
                 end

--- a/spec/classes/document_search_spec.rb
+++ b/spec/classes/document_search_spec.rb
@@ -495,13 +495,14 @@ describe DocumentSearch do
                          ])
       end
 
+      let(:search_options) do
+        { handles: handles, language: :en, query: query, size: 10, offset: 0, include: %w[audience
+                                                                                          content_type
+                                                                                          mime_type] }
+      end
+
       context "when filtering by #{field}" do
-        let(:document_search) do
-          described_class.new(search_options.merge("#{field}": content,
-                                                   include: %w[audience
-                                                               content_type
-                                                               mime_type]))
-        end
+        let(:document_search) { described_class.new(search_options.merge("#{field}": content)) }
 
         it 'returns matches' do
           expect(document_search_results.total).to eq(1)
@@ -511,6 +512,25 @@ describe DocumentSearch do
 
       context "when filtering by a partial #{field} term" do
         let(:document_search) { described_class.new(search_options.merge("#{field}": content.chop)) }
+
+        it 'does not return partially matching results' do
+          expect(document_search_results.total).to eq(0)
+        end
+      end
+
+      context 'when the query matches audience' do
+        let(:document_search) do
+          described_class.new(search_options.merge(query: 'everyone'))
+        end
+
+        it 'returns results matching that tag' do
+          expect(document_search_results.total).to eq(1)
+          expect(document_search_results.results.first['audience']).to eq('everyone')
+        end
+      end
+
+      context 'when the query partially matches audience' do
+        let(:document_search) { described_class.new(search_options.merge(query: 'one')) }
 
         it 'does not return partially matching results' do
           expect(document_search_results.total).to eq(0)
@@ -531,14 +551,17 @@ describe DocumentSearch do
                          ])
       end
 
+      let(:search_options) do
+        { handles: handles, language: :en, query: query, size: 10, offset: 0, include: %w[searchgov_custom1
+                                                                                          searchgov_custom2
+                                                                                          searchgov_custom3
+                                                                                          tags] }
+      end
+
       context "when filtering by one #{field} term" do
         let(:filter_value) { content.split(', ').sample(1) }
         let(:document_search) do
-          described_class.new(search_options.merge("#{field}": filter_value,
-                                                   include: %w[searchgov_custom1
-                                                               searchgov_custom2
-                                                               searchgov_custom3
-                                                               tags]))
+          described_class.new(search_options.merge("#{field}": filter_value))
         end
 
         it 'returns results matching that single term' do
@@ -559,16 +582,29 @@ describe DocumentSearch do
       context "when filtering by the entire #{field} array" do
         let(:filter_value) { content.split(', ') }
         let(:document_search) do
-          described_class.new(search_options.merge("#{field}": filter_value,
-                                                   include: %w[searchgov_custom1
-                                                               searchgov_custom2
-                                                               searchgov_custom3
-                                                               tags]))
+          described_class.new(search_options.merge("#{field}": filter_value))
         end
 
         it 'returns results matching the entire array' do
           expect(document_search_results.total).to eq(1)
           expect(document_search_results.results.first[field]).to eq(filter_value)
+        end
+      end
+
+      context "when the query matches a single #{field} term" do
+        let(:query) { content.split(', ').sample(1).first }
+
+        it 'returns results matching that field' do
+          expect(document_search_results.total).to eq(1)
+          expect(document_search_results.results.first[field]).to match(array_including(query))
+        end
+      end
+
+      context "when the query partially matches a #{field} term" do
+        let(:query) { content.split(', ').sample(1).first.chop }
+
+        it 'does not return partially matching results' do
+          expect(document_search_results.total).to eq(0)
         end
       end
     end


### PR DESCRIPTION
## Summary
- Updates i14y so to include `audience` and `searchgov_custom`s in query matching;
- Extends existing logic for `tags` querying to the `searchgov_custom` fields (e.g. downcases search, requires exact match on term, etc.)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
