### PR TITLE
SRCH-1719 Make ElasticSearch 7 the default for development and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,4 +65,4 @@ workflows:
                 # not yet compatible with Ruby 3.x
               elasticsearch_version:
                 - 7.17.7
-                # - 8.5.3
+                # not yet compatible with Elasticsearch 8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - image: cimg/ruby:<< parameters.ruby_version >>
         # Using custom Docker images including required Elasticsearch plugins.
         # See Dockerfile.elasticsearch* for details
-      - image: docker.elastic.co/elasticsearch/elasticsearch:<< parameters.elasticsearch_version >>
+      - image: searchgov/elasticsearch:<< parameters.elasticsearch_version >>
         environment:
           - bootstrap.memory_lock=true
           - discovery.type=single-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,5 +64,5 @@ workflows:
                 - 2.7.5
                 # not yet compatible with Ruby 3.x
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
+                - 8.5.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - image: cimg/ruby:<< parameters.ruby_version >>
         # Using custom Docker images including required Elasticsearch plugins.
         # See Dockerfile.elasticsearch* for details
-      - image: searchgov/elasticsearch:<< parameters.elasticsearch_version >>
+      - image: docker.elastic.co/elasticsearch/elasticsearch:<< parameters.elasticsearch_version >>
         environment:
           - bootstrap.memory_lock=true
           - discovery.type=single-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,5 +64,5 @@ workflows:
                 - 2.7.5
                 # not yet compatible with Ruby 3.x
               elasticsearch_version:
-                - 7.17.3
-                - 8.5.3
+                - 7.17.7
+                # - 8.5.3

--- a/README.md
+++ b/README.md
@@ -21,24 +21,24 @@ The Elasticsearch services provided by `searchgov-services` is configured to run
 
     ES_HOSTS=localhost:9207 bundle exec rspec spec
 
-Verify that Elasticsearch 6.8.x is running on the expected port (port 9200 by default):
+Verify that Elasticsearch 7.17.x is running on the expected port (port 9200 by default):
 
 ```
 $ curl localhost:9200
 {
-  "name" : "wp9TsCe",
-  "cluster_name" : "docker-cluster",
-  "cluster_uuid" : "WGf_peYTTZarT49AtEgc3g",
+  "name" : "002410188f61",
+  "cluster_name" : "es7-docker-cluster",
+  "cluster_uuid" : "l3cAhBd4Sqa3B4SkpUilPQ",
   "version" : {
-    "number" : "6.8.7",
+    "number" : "7.17.7",
     "build_flavor" : "default",
     "build_type" : "docker",
-    "build_hash" : "c63e621",
-    "build_date" : "2020-02-26T14:38:01.193138Z",
+    "build_hash" : "78dcaaa8cee33438b91eca7f5c7f56a70fec9e80",
+    "build_date" : "2022-10-17T15:29:54.167373105Z",
     "build_snapshot" : false,
-    "lucene_version" : "7.7.2",
-    "minimum_wire_compatibility_version" : "5.6.0",
-    "minimum_index_compatibility_version" : "5.0.0"
+    "lucene_version" : "8.11.1",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
   },
   "tagline" : "You Know, for Search"
 }
@@ -101,7 +101,7 @@ $ curl -u dev:devpwd http://localhost:8081/api/v1/collections/search?handles=tes
 
 ## Tests
 ```
-# Fire up Elasticsearch
+# Fire up Elasticsearch in search-services
 $ docker-compose up elasticsearch
 
 $ bundle exec rake i14y:setup

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ curl -u dev:devpwd http://localhost:8081/api/v1/collections/search?handles=tes
 ## Tests
 ```
 # Fire up Elasticsearch in search-services
-$ docker-compose up elasticsearch
+$ docker-compose up elasticsearch7
 
 $ bundle exec rake i14y:setup
 $ rake


### PR DESCRIPTION
## Summary
This PR removes ElasticSearch 6 from the CI matrix and updates the README to reference ElasticSearch 7.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
