### PR TITLE
SRCH-4003 bug: invalid thumbnail_url should not block indexing page c…

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -28,11 +28,11 @@ class Document
   attribute :updated_at, Time, default: proc { Time.now.utc }
   attribute :updated, DateTime
 
-  validates :thumbnail_url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_blank: true
   validates :language, presence: true
   validates :path, presence: true
 
   validate :mime_type_is_valid
+  validate :thumbnail_url_is_valid
 
   private
 
@@ -40,5 +40,12 @@ class Document
     return unless mime_type
 
     errors.add(:mime_type, 'is invalid') unless MiniMime.lookup_by_content_type(mime_type)
+  end
+
+  def thumbnail_url_is_valid
+    unless thumbnail_url =~ URI::DEFAULT_PARSER.make_regexp
+      Rails.logger.info "#{thumbnail_url} is invalid format URL"
+      self.thumbnail_url = nil
+    end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -43,9 +43,9 @@ class Document
   end
 
   def thumbnail_url_is_valid
-    unless thumbnail_url =~ URI::DEFAULT_PARSER.make_regexp
-      Rails.logger.info "#{thumbnail_url} is invalid format URL"
-      self.thumbnail_url = nil
-    end
+    return if thumbnail_url&.match?(URI::DEFAULT_PARSER.make_regexp)
+
+    Rails.logger.info "#{thumbnail_url} is invalid format URL"
+    self.thumbnail_url = nil
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -92,11 +92,11 @@ describe Document do
         described_class.new(valid_params.merge(thumbnail_url: 'invalid thumbnail url'))
       end
 
-      it { is_expected.to be_invalid }
+      it { is_expected.to be_valid }
 
-      it 'generates an error message' do
+      it 'has a value as nil' do
         document.valid?
-        expect(document.errors.messages[:thumbnail_url]).to include 'is invalid'
+        expect(document.thumbnail_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary
- Set value to `nil` for invalid `thumbnail_url`, so that it will not block indexing URL.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".
