### PR TITLE
SRCH-4594 Disable Elasticsearch discovery

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -4,7 +4,7 @@ module ES
   ES_CONFIG = Rails.application.config_for(:elasticsearch).freeze
 
   def self.client
-    Elasticsearch::Client.new(ES_CONFIG.merge({randomize_hosts: true, retry_on_failure: true, reload_connections: true}))
+    Elasticsearch::Client.new(ES_CONFIG.merge({randomize_hosts: true, retry_on_failure: true, reload_connections: false, reload_on_failure: false}))
   end
 
   def self.collection_repository


### PR DESCRIPTION
## Summary
This PR disables the `reload_on_connections` and `reload_on_failure` Elasticsearch client options in order to address an issue with ES connections in production.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
